### PR TITLE
修改镜像链接

### DIFF
--- a/mirrors/index.html
+++ b/mirrors/index.html
@@ -44,7 +44,7 @@ var _hmt = _hmt || [];
 <hr>
 <h2>镜像存储库</h2>
 <hr>
-<a href="https://hub.fastgit.org/DiamondDA/VM-Library-Xnix-Repo">*NIX分区</a>
+<a href="https://github.com/DiamondDA/VM-Library-Xnix-Repo">*NIX分区</a>
 <hr>
 <button style="width: 80px;height: 40px;background: none;border: #4CAF50 solid 1px;">按钮</button>
 </html>


### PR DESCRIPTION
fastgit.org提示响应时间过长，已更改为github.com